### PR TITLE
DM-40563: Persist ObservationIdentifiers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 24.1.1
+    rev: 24.4.2
     hooks:
       - id: black
         language_version: python3.11
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.2.0
+    rev: v0.4.3
     hooks:
       - id: ruff
   - repo: https://github.com/pycqa/isort

--- a/doc/changes/DM-40563.api.rst
+++ b/doc/changes/DM-40563.api.rst
@@ -1,0 +1,1 @@
+Replace "BAND" in the header with a more standard "FILTER" keyword.

--- a/doc/changes/DM-40563.feature.rst
+++ b/doc/changes/DM-40563.feature.rst
@@ -1,0 +1,1 @@
+Persist information about the input visits (+detectors) to each cell in separate HDUs.

--- a/python/lsst/cell_coadds/_fits.py
+++ b/python/lsst/cell_coadds/_fits.py
@@ -360,7 +360,7 @@ def writeMultipleCellCoaddAsFits(
     filename: str,
     overwrite: bool = False,
     metadata: PropertySet | None = None,
-) -> None:
+) -> fits.HDUList:
     """Write a MultipleCellCoadd object to a FITS file.
 
     Parameters
@@ -475,3 +475,5 @@ def writeMultipleCellCoaddAsFits(
 
     hdu_list = fits.HDUList([primary_hdu, hdu])
     hdu_list.writeto(filename, overwrite=overwrite)
+
+    return hdu_list

--- a/python/lsst/cell_coadds/_fits.py
+++ b/python/lsst/cell_coadds/_fits.py
@@ -106,7 +106,7 @@ from ._image_planes import OwnedImagePlanes
 from ._multiple_cell_coadd import MultipleCellCoadd, SingleCellCoadd
 from ._uniform_grid import UniformGrid
 
-FILE_FORMAT_VERSION = "0.2"
+FILE_FORMAT_VERSION = "0.3"
 """Version number for the file format as persisted, presented as a string of
 the form M.m, where M is the major version, m is the minor version.
 """

--- a/python/lsst/cell_coadds/_fits.py
+++ b/python/lsst/cell_coadds/_fits.py
@@ -212,6 +212,10 @@ class CellCoaddFitsReader:
 
             written_version = version.parse(written_version)
 
+            # TODO: Remove this when FILE_FORMAT_VERSION is bumped to 1.0
+            if written_version < version.parse("0.3"):
+                header.rename_keyword("BAND", "FILTER")
+
             data = hdu_list[1].data
 
             # Read in WCS
@@ -223,12 +227,12 @@ class CellCoaddFitsReader:
             common = CommonComponents(
                 units=CoaddUnits(1),  # TODO: read from FITS TUNIT1 (DM-40562)
                 wcs=wcs,
-                band=header["BAND"],
+                band=header["FILTER"],
                 identifiers=PatchIdentifiers(
                     skymap=header["SKYMAP"],
                     tract=header["TRACT"],
                     patch=Index2D(x=header["PATCH_X"], y=header["PATCH_Y"]),
-                    band=header["BAND"],
+                    band=header["FILTER"],
                 ),
             )
 
@@ -550,7 +554,7 @@ def writeMultipleCellCoaddAsFits(
     # This assumed to be the same as multiple_cell_coadd.common.identifers.band
     # See DM-38843.
     hdu.header["INSTRUME"] = instrument
-    hdu.header["BAND"] = multiple_cell_coadd.common.band
+    hdu.header["FILTER"] = multiple_cell_coadd.common.band
     hdu.header["SKYMAP"] = multiple_cell_coadd.common.identifiers.skymap
     hdu.header["TRACT"] = multiple_cell_coadd.common.identifiers.tract
     hdu.header["PATCH_X"] = multiple_cell_coadd.common.identifiers.patch.x

--- a/python/lsst/cell_coadds/_single_cell_coadd.py
+++ b/python/lsst/cell_coadds/_single_cell_coadd.py
@@ -85,7 +85,7 @@ class SingleCellCoadd(CommonComponentsProperties):
         self._common = common
         # Remove any duplicate elements in the input, sorted them and make
         # them an immutable sequence.
-        # TODO: Remove the conditioning in DM-40563.
+        # TODO: Remove support for inputs as None when bumping to v1.0 .
         self._inputs = tuple(sorted(set(inputs))) if inputs else ()
         self._identifiers = identifiers
 
@@ -107,7 +107,7 @@ class SingleCellCoadd(CommonComponentsProperties):
         return self._psf
 
     @property
-    # TODO: Remove the conditioning in DM-40563.
+    # TODO: Remove the option of returning empty tuple in v1.0.
     def inputs(self) -> tuple[ObservationIdentifiers, ...] | tuple[()]:
         """Identifiers for the input images that contributed to this cell,
         sorted by their `visit` attribute first, and then by `detector`.

--- a/tests/test_coadds.py
+++ b/tests/test_coadds.py
@@ -268,11 +268,13 @@ class BaseMultipleCellCoaddTestCase(lsst.utils.tests.TestCase):
             self.assertMasksEqual(mcc1.cells[idx].outer.mask, mcc2.cells[idx].outer.mask)
             self.assertImagesEqual(mcc1.cells[idx].outer.variance, mcc2.cells[idx].outer.variance)
             self.assertImagesEqual(mcc1.cells[idx].psf_image, mcc2.cells[idx].psf_image)
+            self.assertEqual(mcc1.cells[idx].inputs, mcc2.cells[idx].inputs)
 
             self.assertEqual(mcc1.cells[idx].band, mcc1.band)
             self.assertEqual(mcc1.cells[idx].common, mcc1.common)
             self.assertEqual(mcc1.cells[idx].units, mcc2.units)
             self.assertEqual(mcc1.cells[idx].wcs, mcc1.wcs)
+
             # Identifiers differ because of the ``cell`` component.
             # Check the other attributes within the identifiers.
             for attr in ("skymap", "tract", "patch", "band"):


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [x] updated the FILE_FORMAT_VERSION number correctly (if `python/lsst/cell_coadds/_fits.py` was modified)