### PR TITLE
DM-44233: Remove packed from ObservationIdentifiers

### DIFF
--- a/doc/changes/DM-44233.api.rst
+++ b/doc/changes/DM-44233.api.rst
@@ -1,0 +1,1 @@
+Removed `packed` attribute from `ObservationIdentifiers`.

--- a/python/lsst/cell_coadds/_identifiers.py
+++ b/python/lsst/cell_coadds/_identifiers.py
@@ -32,7 +32,6 @@ from dataclasses import dataclass
 from typing import Self, cast
 
 from lsst.daf.butler import DataCoordinate, DimensionRecord
-from lsst.pipe.base import Instrument
 from lsst.skymap import Index2D
 
 
@@ -130,11 +129,6 @@ class ObservationIdentifiers:
     """Name of the physical filter that this observation was taken with.
     """
 
-    packed: int
-    """ID that uniquely identifies both the visit and detector by packing
-    together their IDs.
-    """
-
     visit: int
     """Unique identifier for the visit.
 
@@ -173,15 +167,11 @@ class ObservationIdentifiers:
         identifiers : `ObservationIdentifiers`
             Struct of identifiers for this observation.
         """
-        packer = Instrument.make_default_dimension_packer(data_id, is_exposure=False)
         detector = data_id.get("detector", backup_detector)
         day_obs = data_id.get("day_obs", None)
         return cls(
             instrument=cast(str, data_id["instrument"]),
             physical_filter=cast(str, data_id["physical_filter"]),
-            # Passing detector twice does not crash the packer. So send it in
-            # without checking if available in data_id.
-            packed=cast(int, packer.pack(data_id, detector=detector, returnMaxBits=False)),
             visit=cast(int, data_id["visit"]),
             day_obs=cast(int, day_obs),
             detector=cast(int, detector),

--- a/python/lsst/cell_coadds/_identifiers.py
+++ b/python/lsst/cell_coadds/_identifiers.py
@@ -188,4 +188,4 @@ class ObservationIdentifiers:
         )
 
     def __lt__(self, other: Self, /) -> bool:
-        return self.packed < other.packed
+        return (self.visit, self.detector) < (other.visit, other.detector)

--- a/python/lsst/cell_coadds/_single_cell_coadd.py
+++ b/python/lsst/cell_coadds/_single_cell_coadd.py
@@ -110,7 +110,7 @@ class SingleCellCoadd(CommonComponentsProperties):
     # TODO: Remove the conditioning in DM-40563.
     def inputs(self) -> tuple[ObservationIdentifiers, ...] | tuple[()]:
         """Identifiers for the input images that contributed to this cell,
-        sorted by their `packed` attribute.
+        sorted by their `visit` attribute first, and then by `detector`.
         """
         return self._inputs
 

--- a/tests/test_coadds.py
+++ b/tests/test_coadds.py
@@ -211,7 +211,6 @@ class BaseMultipleCellCoaddTestCase(lsst.utils.tests.TestCase):
                                 physical_filter="dummy-I",
                                 visit=12345,
                                 detector=67,
-                                packed=13579,
                                 day_obs=20000101,
                             ),
                         ),


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] updated the FILE_FORMAT_VERSION number correctly (if `python/lsst/cell_coadds/_fits.py` was modified)