### PR TITLE
DM-40562: Read pixel units from the FITS header

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -37,3 +37,7 @@ ignore_missing_imports = True
 # mypy does not bode well with monkey patching done here.
 [mypy-lsst.cell_coadds._GridContainer]
 ignore_errors = True
+
+# _cell_coadd_builder.py is not used, and not worth the upkeep.
+[mypy-lsst.cell_coadds._cell_coadd_builder]
+ignore_errors = True

--- a/python/lsst/cell_coadds/_common_components.py
+++ b/python/lsst/cell_coadds/_common_components.py
@@ -44,16 +44,16 @@ class CoaddUnits(enum.Enum):
     flux unit other than nJy).
     """
 
-    legacy = enum.auto()
+    legacy = "legacy"
     """Pixels in semi-arbitrary unit obtained by scaling the warps to a common
     zeropoint (typically 27).
     """
 
-    nJy = enum.auto()
+    nJy = "nJy"
     """Pixels represent flux in nanojanskies.
     """
 
-    chi = enum.auto()
+    chi = "chi"
     """Pixels represent a signal-to-noise ratio.
     """
 

--- a/python/lsst/cell_coadds/_fits.py
+++ b/python/lsst/cell_coadds/_fits.py
@@ -238,7 +238,7 @@ class CellCoaddFitsReader:
 
             # Build the quantities needed to construct a MultipleCellCoadd.
             common = CommonComponents(
-                units=CoaddUnits(1),  # TODO: read from FITS TUNIT1 (DM-40562)
+                units=CoaddUnits(header["TUNIT1"]),
                 wcs=wcs,
                 band=header["FILTER"],
                 identifiers=PatchIdentifiers(

--- a/python/lsst/cell_coadds/_identifiers.py
+++ b/python/lsst/cell_coadds/_identifiers.py
@@ -168,7 +168,7 @@ class ObservationIdentifiers:
             Struct of identifiers for this observation.
         """
         detector = data_id.get("detector", backup_detector)
-        day_obs = data_id.get("day_obs", None)
+        day_obs = data_id.get("day_obs")
         return cls(
             instrument=cast(str, data_id["instrument"]),
             physical_filter=cast(str, data_id["physical_filter"]),

--- a/python/lsst/cell_coadds/_identifiers.py
+++ b/python/lsst/cell_coadds/_identifiers.py
@@ -174,7 +174,7 @@ class ObservationIdentifiers:
             physical_filter=cast(str, data_id["physical_filter"]),
             visit=cast(int, data_id["visit"]),
             day_obs=cast(int, day_obs),
-            detector=cast(int, detector),
+            detector=detector,
         )
 
     def __lt__(self, other: Self, /) -> bool:

--- a/tests/test_coadds.py
+++ b/tests/test_coadds.py
@@ -66,7 +66,7 @@ class BaseMultipleCellCoaddTestCase(lsst.utils.tests.TestCase):
         np.random.seed(42)
         data_id = test_utils.generate_data_id()
         common = CommonComponents(
-            units=CoaddUnits.legacy,  # units here are arbitrary.
+            units=CoaddUnits.nJy,  # units here are arbitrary.
             wcs=test_utils.generate_wcs(),
             band=data_id["band"],
             identifiers=PatchIdentifiers.from_data_id(data_id),

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -46,6 +46,12 @@ class CommonComponentsTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(self.common.band, self.band)
         self.assertEqual(self.common.identifiers, self.identifiers)
 
+    def test_coaddUnits(self):
+        """Test that the member name and values are the same."""
+        for unit in CoaddUnits:
+            with self.subTest(unit.name):
+                self.assertEqual(unit.name, unit.value)
+
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):
     """Check for resource/memory leaks."""

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -33,7 +33,7 @@ class CommonComponentsTestCase(lsst.utils.tests.TestCase):
         self.units = CoaddUnits.nJy
         quantum_data_id = test_utils.generate_data_id()
         self.wcs = test_utils.generate_wcs()
-        self.band = quantum_data_id.get("band", None)
+        self.band = quantum_data_id.get("band")
         self.identifiers = PatchIdentifiers.from_data_id(quantum_data_id)
         self.common = CommonComponents(
             units=self.units, wcs=self.wcs, band=self.band, identifiers=self.identifiers


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] updated the FILE_FORMAT_VERSION number correctly (if `python/lsst/cell_coadds/_fits.py` was modified)