### PR TITLE
DM-48321: Ignore dist-info directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ pytest_session.txt
 
 # Ruff
 .ruff_cache/
+python/*.dist-info/


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] updated the FILE_FORMAT_VERSION number correctly (if `python/lsst/cell_coadds/_fits.py` was modified)