### PR TITLE
DM-48653: Handle borders correctly when stitching together cells 

### DIFF
--- a/python/lsst/cell_coadds/_single_cell_coadd.py
+++ b/python/lsst/cell_coadds/_single_cell_coadd.py
@@ -81,7 +81,7 @@ class SingleCellCoadd(CommonComponentsProperties):
         self._outer = outer
         self._psf = psf
         self._inner_bbox = inner_bbox
-        self._inner = ViewImagePlanes(outer, bbox=inner_bbox, make_view=self._make_view)
+        self._inner = ViewImagePlanes(outer, bbox=inner_bbox, make_view=self.make_view)
         self._common = common
         # Remove any duplicate elements in the input, sorted them and make
         # them an immutable sequence.
@@ -131,5 +131,21 @@ class SingleCellCoadd(CommonComponentsProperties):
         # Docstring inherited.
         return self._common
 
-    def _make_view(self, image: ImageLike) -> ImageLike:
-        return image[self._inner_bbox]
+    def make_view(self, image: ImageLike, bbox: Box2I | None = None) -> ImageLike:
+        """Make a view of an image, optionally within a given bounding box.
+
+        Parameters
+        ----------
+        image : `ImageLike`
+            The image to make a view of.
+        bbox : `Box2I`, optional
+            The bounding box within which to make the view.
+
+        Returns
+        -------
+        image_view: `ImageLike`
+            The view of the image.
+        """
+        if bbox is None:
+            bbox = self._inner_bbox
+        return image[bbox]

--- a/python/lsst/cell_coadds/_stitched_coadd.py
+++ b/python/lsst/cell_coadds/_stitched_coadd.py
@@ -24,13 +24,14 @@ from __future__ import annotations
 __all__ = ("StitchedCoadd",)
 
 from collections.abc import Iterator, Set
+from functools import partial
 from typing import TYPE_CHECKING
 
 from lsst.afw.image import ExposureF, FilterLabel, PhotoCalib
-from lsst.geom import Box2I
+from lsst.geom import Box2I, Point2I
 
 from ._common_components import CoaddUnits, CommonComponents, CommonComponentsProperties
-from ._image_planes import ImagePlanes
+from ._image_planes import ImagePlanes, ViewImagePlanes
 from ._stitched_image_planes import StitchedImagePlanes
 from ._stitched_psf import StitchedPsf
 from ._uniform_grid import UniformGrid
@@ -96,8 +97,27 @@ class StitchedCoadd(StitchedImagePlanes, CommonComponentsProperties):
 
     def _iter_cell_planes(self) -> Iterator[ImagePlanes]:
         # Docstring inherited.
+        x_max, y_max = self._cell_coadd.cells.last.identifiers.cell
+
         for cell in self._cell_coadd.cells.values():
-            yield cell.inner
+            bbox = cell.inner.bbox
+            if cell.identifiers.cell.x == 0:
+                # This is a special case for the first column of cells.
+                bbox.include(Point2I(cell.outer.bbox.beginX, cell.outer.bbox.centerY))
+            elif cell.identifiers.cell.x == x_max:
+                # This is a special case for the last column of cells.
+                bbox.include(Point2I(cell.outer.bbox.endX, cell.outer.bbox.centerY))
+
+            if cell.identifiers.cell.y == 0:
+                # This is a special case for the last row of cells.
+                bbox.include(Point2I(cell.outer.bbox.centerX, cell.outer.bbox.beginY))
+            elif cell.identifiers.cell.y == y_max:
+                # This is a special case for the first row of cells.
+                bbox.include(Point2I(cell.outer.bbox.centerX, cell.outer.bbox.endY))
+
+            bbox.clip(cell.outer.bbox)
+            make_view = partial(cell.make_view, bbox=bbox)
+            yield ViewImagePlanes(cell.outer, bbox=bbox, make_view=make_view)
 
     @property
     def n_noise_realizations(self) -> int:

--- a/python/lsst/cell_coadds/_stitched_coadd.py
+++ b/python/lsst/cell_coadds/_stitched_coadd.py
@@ -49,7 +49,7 @@ class StitchedCoadd(StitchedImagePlanes, CommonComponentsProperties):
         Cell-based coadd to stitch together.
     bbox : `Box2I`, optional
         The region over which a contiguous coadd is desired.  Defaults to
-        ``cell_coadd.inner_bbox``.
+        ``cell_coadd.outer_bbox``.
 
     Notes
     -----

--- a/tests/test_coadds.py
+++ b/tests/test_coadds.py
@@ -476,6 +476,20 @@ class StitchedCoaddTestCase(BaseMultipleCellCoaddTestCase):
                 self.assertImagesEqual(exposure.variance[bbox], self.exposures[index].variance[bbox])
                 self.assertImagesEqual(exposure.mask[bbox], self.exposures[index].mask[bbox])
 
+    def test_borders(self):
+        """Test that the borders are populated correctly on stitching."""
+        mi = self.stitched_coadd.asMaskedImage()
+
+        # Check that the borders are not all zero.
+        with self.assertRaises(AssertionError):
+            np.testing.assert_array_equal(mi.image.array[: self.border_size, :], 0)
+        with self.assertRaises(AssertionError):
+            np.testing.assert_array_equal(mi.image.array[-self.border_size :, :], 0)
+        with self.assertRaises(AssertionError):
+            np.testing.assert_array_equal(mi.image.array[:, : self.border_size], 0)
+        with self.assertRaises(AssertionError):
+            np.testing.assert_array_equal(mi.image.array[:, -self.border_size :], 0)
+
     def test_fits(self):
         """Test that we can write an Exposure with StitchedPsf to a FITS file
         and read it.


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] updated the FILE_FORMAT_VERSION number correctly (if `python/lsst/cell_coadds/_fits.py` was modified)