### PR TITLE
DM-48683: Attach aperture correction maps to cell-based coadds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,22 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 25.1.0
     hooks:
       - id: black
         language_version: python3.11
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.3
+    rev: v0.11.0
     hooks:
       - id: ruff
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         name: isort (python)

--- a/doc/changes/DM-48683.api.rst
+++ b/doc/changes/DM-48683.api.rst
@@ -1,0 +1,2 @@
+Add TUNIT4 to the FITS header to denote the units of the variance plane.
+Add BUNIT to the FITS header when converting to an afw Exposure.

--- a/doc/changes/DM-48683.bug.rst
+++ b/doc/changes/DM-48683.bug.rst
@@ -1,0 +1,1 @@
+Replace TUNI1 with TUNIT2 to denote the units of the image array.

--- a/doc/changes/DM-48683.feature.rst
+++ b/doc/changes/DM-48683.feature.rst
@@ -1,0 +1,1 @@
+Add a new APCORR HDU carrying the aperture correction values for each cell.

--- a/python/lsst/cell_coadds/__init__.py
+++ b/python/lsst/cell_coadds/__init__.py
@@ -19,8 +19,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from . import typing_helpers
+from . import typing_helpers  # noqa: F401
 from ._cell_coadd_builder import *
+from ._coadd_ap_corr_map import *
 from ._common_components import *
 from ._exploded_coadd import *
 from ._fits import *

--- a/python/lsst/cell_coadds/_coadd_ap_corr_map.py
+++ b/python/lsst/cell_coadds/_coadd_ap_corr_map.py
@@ -1,0 +1,245 @@
+# This file is part of cell_coadds.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = (
+    "CoaddApCorrMapStacker",
+    "EMPTY_AP_CORR_MAP",
+)
+
+
+from collections.abc import Iterable
+
+import numpy as np
+from frozendict import frozendict
+
+from lsst.afw.image import ApCorrMap
+from lsst.afw.math import BoundedField
+from lsst.geom import Point2D
+
+from .typing_helpers import SingleCellCoaddApCorrMap
+
+EMPTY_AP_CORR_MAP: SingleCellCoaddApCorrMap = frozendict()
+"""Default empty aperture correction map for a single cell coadd."""
+
+
+class CoaddApCorrMapStacker:
+    """Online aperture correction map for a cell-based coadd.
+
+    This class is responsible for implementing the logic to coadd the
+    aperture correction values and their uncertainties.
+
+    Parameters
+    ----------
+    evaluation_point : `~lsst.geom.Point2D`
+        The point at which the input aperture correction is evaluated.
+    do_coadd_inverse_ap_corr : `bool`, optional
+        If True, the inverse aperture correction is applied to the coadd.
+
+    Notes
+    -----
+    At least one of class variables are set dynamically the first time the
+    ``add`` method is called on any instance of this class. This behavior
+    is based on the practical assumption that all ``ApCorrMap`` instances will
+    have the same set of field names during the entire processing. A schema
+    is therefore not expected at the time of initialization.
+    """
+
+    _ap_corr_names: Iterable[str] = ()
+    """An iterable of algorithm names that have aperture correction values."""
+    # This is set when the first time the add method is called on any instance.
+
+    def __init__(self, evaluation_point: Point2D, do_coadd_inverse_ap_corr: bool = True) -> None:
+        # Initialize frozen attributes.
+        self._evaluation_point = evaluation_point
+        self._do_coadd_inverse_ap_corr = do_coadd_inverse_ap_corr
+
+        # Initialize mutable attributes.
+        self._total_weight = 0.0
+        self._intermediate_ap_corr_map: dict[str, float] = {}
+
+    @classmethod
+    def _setup_ap_corr_names(cls, ap_corr_map: ApCorrMap) -> None:
+        """Set up the aperture correction name set.
+
+        Parameters
+        ----------
+        ap_corr_map : `~lsst.meas.base.ApCorrMap`
+            The aperture correction map to add.
+
+        Raises
+        ------
+        RuntimeError
+            Raised if the keys in `ap_corr_map` do not end in "_instFlux" or
+            "_instFluxErr".
+        """
+        ap_corr_name_set = set()
+        for field_name in ap_corr_map:
+            algorithm_name, suffix = field_name.split("_instFlux")
+            if suffix not in ("", "Err"):
+                raise RuntimeError(f"Invalid field name {field_name} in aperture correction map.")
+
+            ap_corr_name_set.add(algorithm_name)
+
+        cls._ap_corr_names = tuple(sorted(ap_corr_name_set))
+
+    @property
+    def evaluation_point(self) -> Point2D:
+        """The point at which the aperture correction is evaluated."""
+        return self._evaluation_point
+
+    @property
+    def do_coadd_inverse_ap_corr(self) -> bool:
+        """If True, the inverse aperture correction is applied to the coadd."""
+        return self._do_coadd_inverse_ap_corr
+
+    @property
+    def ap_corr_names(self) -> Iterable[str]:
+        """Iterable of algorithm names that have aperture correction values."""
+        return self._ap_corr_names
+
+    @property
+    def total_weight(self) -> float:
+        """The total weight of the aperture correction map."""
+        return self._total_weight
+
+    def add(self, ap_corr_map: ApCorrMap, weight: float) -> None:
+        """Add an aperture correction map to the coadd.
+
+        Parameters
+        ----------
+        ap_corr_map : `~lsst.meas.base.ApCorrMap`
+            The aperture correction map to add.
+        weight : `float`
+            The weight to apply to the aperture correction map.
+
+        Raises
+        ------
+        RuntimeError
+            Raised if the keys in `ap_corr_map` do not end in "_instFlux" or
+            "_instFluxErr".
+        ValueError
+            Raised if the aperture correction value or its error is missing.
+        """
+        if not self.ap_corr_names:
+            # Lazily initialize the aperture correction name set.
+            self._setup_ap_corr_names(ap_corr_map)
+
+        if not self._intermediate_ap_corr_map:
+            self._intermediate_ap_corr_map = dict.fromkeys(
+                [f"{algorithm_name}_instFlux" for algorithm_name in self.ap_corr_names]
+                + [f"{algorithm_name}_instFluxErr" for algorithm_name in self.ap_corr_names],
+                0.0,
+            )
+
+        # Accumulate the aperture correction values in a temporary dict.
+        # This is so that if we error out in the middle, we don't leave the
+        # aperture correction map in an inconsistent state.
+        temp_ap_corr_map = dict.fromkeys(self._intermediate_ap_corr_map, 0.0)
+
+        for algorithm_name in self.ap_corr_names:
+            # Accumulate the aperture correction values.
+            ap_corr_field: BoundedField | None
+            if (ap_corr_field := ap_corr_map.get(f"{algorithm_name}_instFlux")) is None:
+                raise ValueError("Missing {algorithm_name} aperture correction map.")
+
+            ap_corr_value = ap_corr_field.evaluate(self.evaluation_point)
+
+            # Calculate the term to accumulate depending on the boolean.
+            if self.do_coadd_inverse_ap_corr:
+                if ap_corr_value == 0:
+                    raise ValueError("This should not have happened. ap_corr_value is zero.")
+                else:
+                    term = weight / ap_corr_value
+            else:
+                term = weight * ap_corr_value
+
+            temp_ap_corr_map[f"{algorithm_name}_instFlux"] = term
+
+            # Accumulate the aperture correction error values.
+            ap_corr_err_field: BoundedField | None
+            if (ap_corr_err_field := ap_corr_map.get(f"{algorithm_name}_instFluxErr")) is None:
+                raise ValueError(f"Missing {algorithm_name} aperture correction error map.")
+
+            ap_corr_err_value = ap_corr_err_field.evaluate(self.evaluation_point)
+
+            # Calculate the term to accumulate depending on the boolean.
+            if self.do_coadd_inverse_ap_corr:
+                term = (weight * ap_corr_err_value) ** 2 / ap_corr_value**4
+            else:
+                term = (weight * ap_corr_err_value) ** 2
+
+            temp_ap_corr_map[f"{algorithm_name}_instFluxErr"] = term
+
+        # Update the intermediate aperture correction map.
+        for key in self._intermediate_ap_corr_map:
+            self._intermediate_ap_corr_map[key] += temp_ap_corr_map[key]
+
+        # Add the weight to the total weight.
+        self._total_weight += weight
+
+    @property
+    def final_ap_corr_map(self) -> SingleCellCoaddApCorrMap:
+        """Final coadded aperture correction map.
+
+        This should be called after all aperture correction maps have been
+        added.
+
+        Raises
+        ------
+        RuntimeError
+            Raised if the total weight is zero.
+        """
+        if self.total_weight == 0 or not self.ap_corr_names:
+            raise RuntimeError("Cannot get an empty aperture correction map.")
+
+        final_ap_corr_map = dict.fromkeys(self._intermediate_ap_corr_map, 0.0)
+
+        # The transformation equation is different for the aperture correction
+        # values and their uncertainties and it also depends on whether we
+        # accumulate the aperture corrections or their inverse.
+
+        if self.do_coadd_inverse_ap_corr:
+            for algorithm_name in self.ap_corr_names:
+                if (
+                    inverse_ap_corr_value := self._intermediate_ap_corr_map[f"{algorithm_name}_instFlux"]
+                ) > 0:
+                    final_ap_corr_map[f"{algorithm_name}_instFlux"] = (
+                        self.total_weight / inverse_ap_corr_value
+                    )
+                final_ap_corr_map[f"{algorithm_name}_instFluxErr"] = (
+                    final_ap_corr_map[f"{algorithm_name}_instFlux"] ** 2
+                    * np.sqrt(self._intermediate_ap_corr_map[f"{algorithm_name}_instFluxErr"])
+                    / self.total_weight
+                )
+        else:
+            for algorithm_name in self.ap_corr_names:
+                final_ap_corr_map[f"{algorithm_name}_instFlux"] = (
+                    self._intermediate_ap_corr_map[f"{algorithm_name}_instFlux"] / self.total_weight
+                )
+                final_ap_corr_map[f"{algorithm_name}_instFluxErr"] = (
+                    np.sqrt(self._intermediate_ap_corr_map[f"{algorithm_name}_instFluxErr"])
+                    / self.total_weight
+                )
+
+        # Return the finalized (immutable) aperture correction map.
+        return frozendict(final_ap_corr_map)

--- a/python/lsst/cell_coadds/_fits.py
+++ b/python/lsst/cell_coadds/_fits.py
@@ -569,6 +569,7 @@ def writeMultipleCellCoaddAsFits(
 
     hdu.header["VERSION"] = FILE_FORMAT_VERSION
     hdu.header["TUNIT1"] = multiple_cell_coadd.common.units.name
+    hdu.header["TUNIT4"] = multiple_cell_coadd.common.units.name + "**2"
     # This assumed to be the same as multiple_cell_coadd.common.identifers.band
     # See DM-38843.
     hdu.header["INSTRUME"] = instrument

--- a/python/lsst/cell_coadds/_fits.py
+++ b/python/lsst/cell_coadds/_fits.py
@@ -239,7 +239,7 @@ class CellCoaddFitsReader:
 
             # Build the quantities needed to construct a MultipleCellCoadd.
             common = CommonComponents(
-                units=CoaddUnits(header["TUNIT1"]),
+                units=CoaddUnits(header["TUNIT2"]),
                 wcs=wcs,
                 band=header["FILTER"],
                 identifiers=PatchIdentifiers(
@@ -568,7 +568,7 @@ def writeMultipleCellCoaddAsFits(
     primary_hdu.header.extend(wcs_cards)
 
     hdu.header["VERSION"] = FILE_FORMAT_VERSION
-    hdu.header["TUNIT1"] = multiple_cell_coadd.common.units.name
+    hdu.header["TUNIT2"] = multiple_cell_coadd.common.units.name
     hdu.header["TUNIT4"] = multiple_cell_coadd.common.units.name + "**2"
     # This assumed to be the same as multiple_cell_coadd.common.identifers.band
     # See DM-38843.

--- a/python/lsst/cell_coadds/_fits.py
+++ b/python/lsst/cell_coadds/_fits.py
@@ -91,6 +91,7 @@ from typing import Any
 
 import numpy as np
 from astropy.io import fits
+from frozendict import frozendict
 from packaging import version
 
 import lsst.afw.geom as afwGeom
@@ -101,14 +102,16 @@ from lsst.geom import Box2I, Extent2I, Point2I
 from lsst.obs.base.formatters.fitsGeneric import FitsGenericFormatter
 from lsst.skymap import Index2D
 
+from ._coadd_ap_corr_map import EMPTY_AP_CORR_MAP
 from ._common_components import CoaddUnits, CommonComponents
 from ._grid_container import GridContainer
 from ._identifiers import CellIdentifiers, ObservationIdentifiers, PatchIdentifiers
 from ._image_planes import OwnedImagePlanes
 from ._multiple_cell_coadd import MultipleCellCoadd, SingleCellCoadd
 from ._uniform_grid import UniformGrid
+from .typing_helpers import SingleCellCoaddApCorrMap
 
-FILE_FORMAT_VERSION = "0.3"
+FILE_FORMAT_VERSION = "0.4"
 """Version number for the file format as persisted, presented as a string of
 the form M.m, where M is the major version, m is the minor version.
 """
@@ -297,18 +300,35 @@ class CellCoaddFitsReader:
                     written_version,
                 )
 
+            try:
+                aperture_correction_hdu = hdu_list[hdu_list.index_of("APCORR")].data
+                assert len(aperture_correction_hdu) == 0 or len(aperture_correction_hdu) == len(
+                    data
+                ), "Aperture correction map is not available for all cells."
+                aperture_correction_grid = self._readApCorr(aperture_correction_hdu, grid_shape)
+            except KeyError:
+                logger.info("Unable to read aperture correction map from the file.")
+                aperture_correction_hdu = EMPTY_AP_CORR_MAP
+
             coadd = MultipleCellCoadd(
                 (
                     self._readSingleCellCoadd(
-                        data=row,
+                        data=data[row_id],
                         header=header,
                         common=common,
-                        inputs=inputs[Index2D(row["cell_id"][0], row["cell_id"][1])],
+                        inputs=inputs[Index2D(data[row_id]["cell_id"][0], data[row_id]["cell_id"][1])],
                         outer_cell_size=outer_cell_size,
                         psf_image_size=psf_image_size,
                         inner_cell_size=grid_cell_size,
+                        aperture_correction_map=aperture_correction_grid.get(
+                            Index2D(
+                                data[row_id]["cell_id"][0].tolist(),
+                                data[row_id]["cell_id"][1].tolist(),
+                            ),
+                            EMPTY_AP_CORR_MAP,
+                        ),
                     )
-                    for row in data
+                    for row_id in range(len(data))
                 ),
                 grid=grid,
                 outer_cell_size=outer_cell_size,
@@ -329,6 +349,7 @@ class CellCoaddFitsReader:
         outer_cell_size: Extent2I,
         inner_cell_size: Extent2I,
         psf_image_size: Extent2I,
+        aperture_correction_map: SingleCellCoaddApCorrMap = EMPTY_AP_CORR_MAP,
     ) -> SingleCellCoadd:
         """Read a coadd from a FITS file.
 
@@ -350,6 +371,9 @@ class CellCoaddFitsReader:
             The size of the PSF image.
         inner_cell_size : `Extent2I`
             The size of the inner cell.
+        aperture_correction_map : `Mapping` [`str`, `float`], optional
+            Mapping of algorithm name to aperture correction value.
+            If None, no aperture correction is applied.
 
         Returns
         -------
@@ -399,6 +423,7 @@ class CellCoaddFitsReader:
             common=common,
             identifiers=identifiers,
             inputs=inputs,
+            aperture_correction_map=aperture_correction_map,
         )
 
     def readWcs(self) -> afwGeom.SkyWcs:
@@ -415,6 +440,39 @@ class CellCoaddFitsReader:
             ps.update(hdu_list[0].header)
         wcs = afwGeom.makeSkyWcs(ps)
         return wcs
+
+    def _readApCorr(
+        self, aperture_correction_hdu: fits.fitsrec.FITS_rec, grid_shape: Index2D
+    ) -> GridContainer[SingleCellCoaddApCorrMap]:
+        """Read the aperture correction map from the FITS file."""
+        column_names = aperture_correction_hdu.names
+        column_names.remove("x")
+        column_names.remove("y")
+
+        gc = GridContainer[SingleCellCoaddApCorrMap](shape=grid_shape)
+        for row_idx in range(len(aperture_correction_hdu)):
+            cell_id = Index2D(
+                x=aperture_correction_hdu["x"][row_idx], y=aperture_correction_hdu["y"][row_idx]
+            )
+            ap_corr_map_dict = {name: float(aperture_correction_hdu[name][row_idx]) for name in column_names}
+            gc[cell_id] = frozendict(ap_corr_map_dict)
+
+        return gc
+
+
+def to_numpy_record(ap_corr_map: Mapping[str, float], xy: Index2D) -> np.record:
+    """Convert the aperture correction map to a numpy record with
+    appropriate data types.
+    """
+    dtypes = [("x", int), ("y", int)] + [(key, float) for key in ap_corr_map]
+    record = np.recarray((1,), dtype=dtypes)[0]
+    for field_name in ap_corr_map:
+        record[field_name] = ap_corr_map[field_name]
+
+    record["x"] = xy.x
+    record["y"] = xy.y
+
+    return record
 
 
 def writeMultipleCellCoaddAsFits(
@@ -526,6 +584,20 @@ def writeMultipleCellCoaddAsFits(
         array=[cell.psf_image.array for cell in multiple_cell_coadd.cells.values()],
     )
 
+    if apcorr := multiple_cell_coadd.cells.first.aperture_correction_map:
+        dtypes = [("x", int), ("y", int)] + [(key, float) for key in apcorr]
+        aperture_correction_recarray = np.rec.fromrecords(
+            recList=[
+                to_numpy_record(cell.aperture_correction_map, cell.identifiers.cell)
+                for cell in multiple_cell_coadd.cells.values()
+                if cell.aperture_correction_map
+            ],
+            dtype=dtypes,
+        )
+        aperture_correction_hdu = fits.BinTableHDU.from_columns(aperture_correction_recarray, name="APCORR")
+    else:
+        aperture_correction_hdu = None
+
     col_defs = fits.ColDefs([cell_id, image, mask, variance, psf])
     hdu = fits.BinTableHDU.from_columns(col_defs)
 
@@ -583,6 +655,9 @@ def writeMultipleCellCoaddAsFits(
         hdu.header.extend(metadata.toDict())
 
     hdu_list = fits.HDUList([primary_hdu, hdu, cell_hdu, visit_hdu])
+    if aperture_correction_hdu:
+        hdu_list.append(aperture_correction_hdu)
+
     hdu_list.writeto(filename, overwrite=overwrite)
 
     return hdu_list

--- a/python/lsst/cell_coadds/_grid_container.py
+++ b/python/lsst/cell_coadds/_grid_container.py
@@ -63,12 +63,12 @@ class GridContainer(MutableMapping[Index2D, T]):
         if index.x < self.offset.x or index.x >= self.offset.x + self.shape.x:
             raise ValueError(
                 f"x index {index.x} out of range; expected a value between {self.offset.x} and "
-                f"{self.offset.x + self.shape.x -1}."
+                f"{self.offset.x + self.shape.x - 1}."
             )
         if index.y < self.offset.y or index.y >= self.offset.y + self.shape.y:
             raise ValueError(
                 f"y index {index.y} out of range; expected a value between {self.offset.y} and "
-                f"{self.offset.y + self.shape.y -1}."
+                f"{self.offset.y + self.shape.y - 1}."
             )
 
     def __repr__(self) -> str:

--- a/python/lsst/cell_coadds/_stitched_coadd.py
+++ b/python/lsst/cell_coadds/_stitched_coadd.py
@@ -152,6 +152,7 @@ class StitchedCoadd(StitchedImagePlanes, CommonComponentsProperties):
         result.setFilter(FilterLabel(band=self.band))
         if self.units is CoaddUnits.nJy:
             result.setPhotoCalib(PhotoCalib(1.0))
+            result.metadata["BUNIT"] = "nJy"
 
         # We can't do result.setId here, because:
         #

--- a/python/lsst/cell_coadds/typing_helpers.py
+++ b/python/lsst/cell_coadds/typing_helpers.py
@@ -24,9 +24,10 @@
 
 from __future__ import annotations
 
-from typing import Protocol, Self, overload
+from typing import Protocol, Self, TypeAlias, overload
 
 import numpy as np
+from frozendict import frozendict
 
 from lsst.geom import Box2I, Point2I
 
@@ -59,3 +60,7 @@ class ImageLike(Protocol):
     @property
     def array(self) -> np.ndarray:  # noqa: D102
         pass
+
+
+SingleCellCoaddApCorrMap: TypeAlias = frozendict[str, float]
+"""A type alias for aperture correction maps for single cell coadds."""

--- a/tests/test_coadd_ap_corr_map.py
+++ b/tests/test_coadd_ap_corr_map.py
@@ -1,0 +1,145 @@
+# This file is part of cell_coadds.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+import numpy as np
+
+import lsst.afw.image as afwImage
+import lsst.afw.math as afwMath
+import lsst.geom as geom
+import lsst.utils.tests
+from lsst.cell_coadds import CoaddApCorrMapStacker
+
+
+class TestCoaddApCorrMapStacker(lsst.utils.tests.TestCase):
+    """Test the CoaddApCorrMap stacker."""
+
+    @classmethod
+    def setUpClass(cls):  # noqa: D102
+        cls.bbox = geom.Box2I(
+            minimum=geom.Point2I(-10, -10),
+            maximum=geom.Point2I(10, 10),
+        )
+        cls.evaluation_point = geom.Point2D(0, 0)
+        cls.visit_count = 5
+        cls.ap_corr_map_list = [afwImage.ApCorrMap() for _ in range(cls.visit_count)]
+        # Set them up to the spatially constant BoundedFields.
+        for idx, ap_corr_map in enumerate(cls.ap_corr_map_list, start=2):
+            ap_corr_map.set(
+                "base_PsfFlux_instFlux", afwMath.ChebyshevBoundedField(cls.bbox, np.array([[1 / idx]]))
+            )
+            ap_corr_map.set(
+                "base_PsfFlux_instFluxErr", afwMath.ChebyshevBoundedField(cls.bbox, np.array([[0.05 / idx]]))
+            )
+            ap_corr_map.set(
+                "base_GaussianFlux_instFlux", afwMath.ChebyshevBoundedField(cls.bbox, np.array([[1.5 / idx]]))
+            )
+            ap_corr_map.set(
+                "base_GaussianFlux_instFluxErr",
+                afwMath.ChebyshevBoundedField(cls.bbox, np.array([[0.6 / idx]])),
+            )
+
+    def test_add_direct_ap_corr(self):
+        """Test that the values are what we expect when adding directly."""
+        stacker = CoaddApCorrMapStacker(
+            evaluation_point=self.evaluation_point,
+            do_coadd_inverse_ap_corr=False,
+        )
+        for idx in range(self.visit_count):
+            stacker.add(
+                self.ap_corr_map_list[idx],
+                weight=1.0,
+            )
+
+        final_ap_corr_map = stacker.final_ap_corr_map
+
+        self.assertFloatsAlmostEqual(
+            final_ap_corr_map["base_PsfFlux_instFlux"],
+            0.29,  # mean of 1/2, 1/3, 1/4, 1/5, 1/6
+            atol=1e-8,
+        )
+        self.assertFloatsAlmostEqual(
+            final_ap_corr_map["base_PsfFlux_instFluxErr"],
+            0.05 * 0.14019827229875395,
+            atol=1e-8,
+        )
+        self.assertFloatsAlmostEqual(
+            final_ap_corr_map["base_GaussianFlux_instFlux"],
+            1.5 * 0.29,
+            atol=1e-8,
+        )
+        self.assertFloatsAlmostEqual(
+            final_ap_corr_map["base_GaussianFlux_instFluxErr"],
+            0.6 * 0.14019827229875395,
+            atol=1e-8,
+        )
+
+    def test_add_inverse_ap_corr(self):
+        """Test that the values are what we expect when adding inverse."""
+        stacker = CoaddApCorrMapStacker(
+            evaluation_point=self.evaluation_point,
+            do_coadd_inverse_ap_corr=True,
+        )
+        for idx in range(self.visit_count):
+            stacker.add(
+                self.ap_corr_map_list[idx],
+                weight=1.0,
+            )
+
+        final_ap_corr_map = stacker.final_ap_corr_map
+
+        self.assertFloatsAlmostEqual(
+            final_ap_corr_map["base_PsfFlux_instFlux"],
+            0.25,
+            atol=1e-8,
+        )
+
+        self.assertFloatsAlmostEqual(
+            final_ap_corr_map["base_GaussianFlux_instFlux"],
+            1.5 * 0.25,
+            atol=1e-8,
+        )
+
+        self.assertFloatsAlmostEqual(
+            final_ap_corr_map["base_PsfFlux_instFluxErr"],
+            0.05 * (0.25**2) * np.sqrt(90) / 5,
+            atol=1e-8,
+        )
+
+        self.assertFloatsAlmostEqual(
+            final_ap_corr_map["base_GaussianFlux_instFluxErr"],
+            0.6 / (1.5**2) * ((1.5 * 0.25) ** 2) * np.sqrt(90) / 5,
+            atol=1e-8,
+        )
+
+
+class TestCoaddApCorrMapMemoryTestCase(lsst.utils.tests.MemoryTestCase):
+    """Test the CoaddApCorrMapStacker for memory leaks."""
+
+
+def setup_module(module):  # noqa: D103
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_coadds.py
+++ b/tests/test_coadds.py
@@ -58,7 +58,7 @@ class BaseMultipleCellCoaddTestCase(lsst.utils.tests.TestCase):
     inner_size: int
     outer_size: int
     test_positions: Iterable[tuple[geom.Point2D, Index2D]]
-    exposures: Mapping[Index2D, lsst.afw.image.ExposureF]
+    exposures: Mapping[Index2D, ExposureF]
     multiple_cell_coadd: MultipleCellCoadd
 
     @classmethod


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [x] updated the FILE_FORMAT_VERSION number correctly (if `python/lsst/cell_coadds/_fits.py` was modified)