### PR TITLE
DM-48683-hotfox: Maintain readability of earlier coadds with TUNIT1

### DIFF
--- a/python/lsst/cell_coadds/_fits.py
+++ b/python/lsst/cell_coadds/_fits.py
@@ -241,8 +241,14 @@ class CellCoaddFitsReader:
             wcs = afwGeom.makeSkyWcs(ps)
 
             # Build the quantities needed to construct a MultipleCellCoadd.
+            if written_version >= version.parse("0.4"):
+                coadd_units = header["TUNIT2"]
+            else:
+                logger.info("Attemping to set pixel units from TUNIT1.")
+                coadd_units = header.get("TUNIT1", CoaddUnits.legacy.name)
+
             common = CommonComponents(
-                units=CoaddUnits(header["TUNIT2"]),
+                units=CoaddUnits(coadd_units),
                 wcs=wcs,
                 band=header["FILTER"],
                 identifiers=PatchIdentifiers(


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] updated the FILE_FORMAT_VERSION number correctly (if `python/lsst/cell_coadds/_fits.py` was modified)