### PR TITLE
DM-48774: Propagate apeture corrections through cell-based coadds

### DIFF
--- a/python/lsst/cell_coadds/__init__.py
+++ b/python/lsst/cell_coadds/__init__.py
@@ -30,6 +30,7 @@ from ._identifiers import *
 from ._image_planes import *
 from ._multiple_cell_coadd import *
 from ._single_cell_coadd import *
+from ._stitched_aperture_correction import *
 from ._stitched_coadd import *
 from ._stitched_image_planes import *
 from ._stitched_psf import *

--- a/python/lsst/cell_coadds/_stitched_aperture_correction.py
+++ b/python/lsst/cell_coadds/_stitched_aperture_correction.py
@@ -1,0 +1,64 @@
+# This file is part of cell_coadds.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import lsst.geom as geom
+from lsst.skymap import Index2D
+
+from ._uniform_grid import UniformGrid
+
+__all__ = ("StitchedApertureCorrection",)
+
+
+class StitchedApertureCorrection:
+    """A class that quacks like BoundedField and defined on a grid piecewise.
+
+    Parameters
+    ----------
+    ugrid : `~lsst.cell_coadds.UniformGrid`
+        The uniform grid that defines the bounding boxes for each piece.
+    gc : `Mapping[Index2D, float]`
+        The grid container that holds the values for each cell.
+    """
+
+    def __init__(self, ugrid: UniformGrid, gc: Mapping[Index2D, float]):
+        self.ugrid = ugrid
+        self.gc = gc
+
+    def evaluate(self, point: geom.Point2D | geom.Point2I) -> float:
+        """Evaluate the BoundedField at a given point on the image.
+
+        Parameters
+        ----------
+        point : `~lsst.geom.Point2D` or `~lsst.geom.Point2I`
+            The point at which to evaluate the BoundedField.
+
+        Returns
+        -------
+        value: `float`
+            The value of the BoundedField at the specified point.
+        """
+        eval_point = geom.Point2I(point)
+        idx = self.ugrid.index(eval_point)
+        return self.gc[idx]

--- a/python/lsst/cell_coadds/typing_helpers.py
+++ b/python/lsst/cell_coadds/typing_helpers.py
@@ -24,12 +24,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Protocol, Self, TypeAlias, overload
 
 import numpy as np
 from frozendict import frozendict
 
 from lsst.geom import Box2I, Point2I
+
+from ._stitched_aperture_correction import StitchedApertureCorrection
 
 
 class ImageLike(Protocol):
@@ -64,3 +67,6 @@ class ImageLike(Protocol):
 
 SingleCellCoaddApCorrMap: TypeAlias = frozendict[str, float]
 """A type alias for aperture correction maps for single cell coadds."""
+
+StitchedCoaddApCorrMap: TypeAlias = Mapping[str, StitchedApertureCorrection]
+"""A type alias for aperture correction maps for stitched coadds."""

--- a/tests/test_coadds.py
+++ b/tests/test_coadds.py
@@ -497,6 +497,19 @@ class StitchedCoaddTestCase(BaseMultipleCellCoaddTestCase):
                 self.assertImagesEqual(exposure.variance[bbox], self.exposures[index].variance[bbox])
                 self.assertImagesEqual(exposure.mask[bbox], self.exposures[index].mask[bbox])
 
+    def test_aperture_correction(self):
+        """Test the aperture correction values are what we expect."""
+        ap_corr_map = self.stitched_coadd.ap_corr_map
+        algorithm_names = ap_corr_map.keys()
+
+        for (position, cellId), algorithm_name in product(self.test_positions, algorithm_names):
+            with self.subTest(x=cellId.x, y=cellId.y, algorithm_name=algorithm_name):
+                field_name = algorithm_name
+                self.assertEqual(
+                    ap_corr_map[field_name].evaluate(position),
+                    self.multiple_cell_coadd.cells[cellId].aperture_correction_map[field_name],
+                )
+
     def test_borders(self):
         """Test that the borders are populated correctly on stitching."""
         mi = self.stitched_coadd.asMaskedImage()


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] updated the FILE_FORMAT_VERSION number correctly (if `python/lsst/cell_coadds/_fits.py` was modified)