### PR TITLE
DM-49843: Preserve the ability to read earlier versions of cell coadds

### DIFF
--- a/python/lsst/cell_coadds/_coadd_ap_corr_map.py
+++ b/python/lsst/cell_coadds/_coadd_ap_corr_map.py
@@ -160,7 +160,7 @@ class CoaddApCorrMapStacker:
             # Accumulate the aperture correction values.
             ap_corr_field: BoundedField | None
             if (ap_corr_field := ap_corr_map.get(f"{algorithm_name}_instFlux")) is None:
-                raise ValueError("Missing {algorithm_name} aperture correction map.")
+                raise ValueError(f"Missing {algorithm_name} aperture correction map.")
 
             ap_corr_value = ap_corr_field.evaluate(self.evaluation_point)
 

--- a/python/lsst/cell_coadds/_fits.py
+++ b/python/lsst/cell_coadds/_fits.py
@@ -313,7 +313,8 @@ class CellCoaddFitsReader:
                 ), "Aperture correction map is not available for all cells."
                 aperture_correction_grid = self._readApCorr(aperture_correction_hdu, grid_shape)
             except KeyError:
-                logger.info("Unable to read aperture correction map from the file.")
+                if written_version >= version.parse("0.4"):
+                    logger.warning("Unable to read aperture correction map from the file.")
                 # Create an empty grid container regardless.
                 aperture_correction_grid = GridContainer[SingleCellCoaddApCorrMap](shape=grid_shape)
 

--- a/python/lsst/cell_coadds/_fits.py
+++ b/python/lsst/cell_coadds/_fits.py
@@ -314,7 +314,8 @@ class CellCoaddFitsReader:
                 aperture_correction_grid = self._readApCorr(aperture_correction_hdu, grid_shape)
             except KeyError:
                 logger.info("Unable to read aperture correction map from the file.")
-                aperture_correction_hdu = EMPTY_AP_CORR_MAP
+                # Create an empty grid container regardless.
+                aperture_correction_grid = GridContainer[SingleCellCoaddApCorrMap](shape=grid_shape)
 
             coadd = MultipleCellCoadd(
                 (


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] updated the FILE_FORMAT_VERSION number correctly (if `python/lsst/cell_coadds/_fits.py` was modified)