### PR TITLE
DM-50358: Account for grid padding when reading in MultipleCellCoadd

### DIFF
--- a/python/lsst/cell_coadds/_multiple_cell_coadd.py
+++ b/python/lsst/cell_coadds/_multiple_cell_coadd.py
@@ -76,10 +76,16 @@ class MultipleCellCoadd(CommonComponentsProperties):
         for cell in cells:
             index = cell.identifiers.cell
             cells_builder[index] = cell
-            if cell.inner.bbox != self._grid.bbox_of(index):
+            cell_bbox = self._grid.bbox_of(index)
+            if not cell.outer.bbox.contains(cell_bbox):
+                raise ValueError(
+                    f"Cell at index {index} has outer bbox {cell.outer.bbox}, "
+                    f"which does not contain {self._grid.bbox_of(index)}."
+                )
+            if not cell_bbox.contains(cell.inner.bbox):
                 raise ValueError(
                     f"Cell at index {index} has inner bbox {cell.inner.bbox}, "
-                    f"but grid expects {self._grid.bbox_of(index)}."
+                    f"which is not contained by {self._grid.bbox_of(index)}."
                 )
             if cell.outer.bbox.getDimensions() != self._outer_cell_size:
                 raise ValueError(

--- a/python/lsst/cell_coadds/_uniform_grid.py
+++ b/python/lsst/cell_coadds/_uniform_grid.py
@@ -188,7 +188,7 @@ class UniformGrid:
     def __repr__(self) -> str:
         return (
             f"UniformGrid(cell_size={repr(self.cell_size)}, shape={self.shape}, "
-            f"min={repr(self.bbox.getMin())})"
+            f"min={repr(self.bbox.getMin())}, padding={self.padding})"
         )
 
     # Convenience methods

--- a/python/lsst/cell_coadds/_uniform_grid.py
+++ b/python/lsst/cell_coadds/_uniform_grid.py
@@ -183,7 +183,11 @@ class UniformGrid:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, UniformGrid):
             return False
-        return self._bbox == other._bbox and self._cell_size == other._cell_size
+        return (
+            self._bbox == other._bbox
+            and self._cell_size == other._cell_size
+            and self._padding == other._padding
+        )
 
     def __repr__(self) -> str:
         return (

--- a/tests/test_coadds.py
+++ b/tests/test_coadds.py
@@ -231,7 +231,7 @@ class BaseMultipleCellCoaddTestCase(lsst.utils.tests.TestCase):
         grid_bbox = geom.Box2I(
             geom.Point2I(cls.x0, cls.y0), geom.Extent2I(cls.nx * cls.inner_size_x, cls.ny * cls.inner_size_y)
         )
-        grid = UniformGrid.from_bbox_shape(grid_bbox, Index2D(x=cls.nx, y=cls.ny))
+        grid = UniformGrid.from_bbox_shape(grid_bbox, Index2D(x=cls.nx, y=cls.ny), padding=cls.border_size)
 
         cls.multiple_cell_coadd = MultipleCellCoadd(
             single_cell_coadds,

--- a/tests/test_coadds.py
+++ b/tests/test_coadds.py
@@ -369,7 +369,7 @@ class ExplodedCoaddTestCase(BaseMultipleCellCoaddTestCase):
         """Test the asMaskedImage method for an ExplodedCoadd object."""
         masked_image = self.exploded_coadd.asMaskedImage()
         masked_image.setXY0(self.multiple_cell_coadd.outer_bbox.getMin())
-        base_bbox = self.multiple_cell_coadd.grid.bbox_of(Index2D(0, 0)).dilatedBy(self.border_size)
+        base_bbox = self.multiple_cell_coadd.cells.first.outer.bbox
         for cell_x, cell_y in product(range(self.nx), range(self.ny)):
             bbox = base_bbox.shiftedBy(geom.Extent2I(cell_x * self.outer_size_x, cell_y * self.outer_size_y))
             with self.subTest(cell_x=cell_x, cell_y=cell_y):

--- a/tests/test_coadds.py
+++ b/tests/test_coadds.py
@@ -121,7 +121,7 @@ class BaseMultipleCellCoaddTestCase(lsst.utils.tests.TestCase):
         # The test points are chosen to cover various corner cases assuming
         # inner_size = (17, 15) and border_size = 5. If that is changed, the
         # test points should be updated to not fall outside the coadd and still
-        # cover the description in the inline comments.
+        # cover the description in the inline comments. This is checked below.
         test_points = (
             geom.Point2D(cls.x0 + 5, cls.y0 + 4),  # inner point in lower left
             geom.Point2D(cls.x0 + 6, cls.y0 + 24),  # inner point in upper left
@@ -232,6 +232,11 @@ class BaseMultipleCellCoaddTestCase(lsst.utils.tests.TestCase):
             geom.Point2I(cls.x0, cls.y0), geom.Extent2I(cls.nx * cls.inner_size_x, cls.ny * cls.inner_size_y)
         )
         grid = UniformGrid.from_bbox_shape(grid_bbox, Index2D(x=cls.nx, y=cls.ny), padding=cls.border_size)
+
+        for test_point, test_index in cls.test_positions:
+            assert test_index == grid.index(
+                geom.Point2I(test_point)
+            ), f"Test point {test_point} is not in cell {test_index}."
 
         cls.multiple_cell_coadd = MultipleCellCoadd(
             single_cell_coadds,

--- a/tests/test_coadds.py
+++ b/tests/test_coadds.py
@@ -264,6 +264,7 @@ class BaseMultipleCellCoaddTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(mcc1.inner_bbox, mcc2.inner_bbox)
         self.assertEqual(mcc1.outer_bbox, mcc2.outer_bbox)
         self.assertEqual(mcc1.outer_cell_size, mcc2.outer_cell_size)
+        self.assertEqual(mcc1.grid, mcc2.grid)
         self.assertEqual(mcc1.mask_fraction_names, mcc2.mask_fraction_names)
         self.assertEqual(mcc1.n_noise_realizations, mcc2.n_noise_realizations)
         self.assertEqual(mcc1.psf_image_size, mcc2.psf_image_size)

--- a/tests/test_grid_container.py
+++ b/tests/test_grid_container.py
@@ -25,6 +25,7 @@ import copy
 import pickle
 import unittest
 
+import lsst.utils.tests
 from lsst.cell_coadds import GridContainer, UniformGrid
 from lsst.geom import Box2I, Extent2I, Point2I
 from lsst.skymap import Index2D
@@ -208,5 +209,14 @@ class GridContainerTestCase(unittest.TestCase):
         self._check(pickled_container)
 
 
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    """Test for memory/resource leaks."""
+
+
+def setup_module(module):  # noqa: D103
+    lsst.utils.tests.init()
+
+
 if __name__ == "__main__":
+    lsst.utils.tests.init()
     unittest.main()

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -39,7 +39,8 @@ class IdentifiersTestCase(unittest.TestCase):
     def test_cell_identifiers(self) -> None:
         """Test we can construct a CellIdentifiers from a DataCoordinate."""
         cellIdentifier = CellIdentifiers.from_data_id(
-            self.data_id, cell=Index2D(x=4, y=2)  # type: ignore [attr-defined]
+            self.data_id,
+            cell=Index2D(x=4, y=2),
         )
         self.assertEqual(cellIdentifier.cell, Index2D(x=4, y=2))
         self.assertEqual(cellIdentifier.tract, 9813)

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -21,6 +21,7 @@
 
 import unittest
 
+import lsst.utils.tests
 from lsst.cell_coadds import CellIdentifiers, ObservationIdentifiers, PatchIdentifiers
 from lsst.cell_coadds.test_utils import generate_data_id
 from lsst.skymap import Index2D
@@ -83,5 +84,14 @@ class IdentifiersTestCase(unittest.TestCase):
             PatchIdentifiers.from_data_id(self.data_id, cell=Index2D(x=4, y=2))  # type: ignore
 
 
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    """Test for memory/resource leaks."""
+
+
+def setup_module(module):  # noqa: D103
+    lsst.utils.tests.init()
+
+
 if __name__ == "__main__":
+    lsst.utils.tests.init()
     unittest.main()

--- a/tests/test_uniform_grid.py
+++ b/tests/test_uniform_grid.py
@@ -48,6 +48,7 @@ class UniformGridTestCase(unittest.TestCase):
         self.bbox = Box2I(Point2I(x=self.x0, y=self.y0), Extent2I(x=self.bw, y=self.bh))
         self.cell_size = Extent2I(x=self.cw, y=self.ch)
         self.shape = Index2D(x=self.nx, y=self.ny)
+        self.padding = 0
 
     def test_ctor_bbox_cell_size(self) -> None:
         """Test UniformGrid after construction with (bbox, cell_size)."""
@@ -68,6 +69,7 @@ class UniformGridTestCase(unittest.TestCase):
         self.assertEqual(grid.bbox, self.bbox)
         self.assertEqual(grid.cell_size, self.cell_size)
         self.assertEqual(grid.shape, self.shape)
+        self.assertEqual(grid.padding, self.padding)
         self.assertIsInstance(grid.shape, Index2D)
         self.assertEqual(grid.bbox_of(Index2D(x=3, y=4)), Box2I(Point2I(x=10, y=10), self.cell_size))
         index = grid.index(Point2I(x=11, y=9))

--- a/tests/test_uniform_grid.py
+++ b/tests/test_uniform_grid.py
@@ -221,5 +221,14 @@ class UniformGridTestCase(unittest.TestCase):
         self.assertRaises(ValueError, grid.index, Point2I(x=self.x0, y=self.y0 + self.bh + padding))
 
 
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    """Test for memory/resource leaks."""
+
+
+def setup_module(module):  # noqa: D103
+    lsst.utils.tests.init()
+
+
 if __name__ == "__main__":
+    lsst.utils.tests.init()
     unittest.main()


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] updated the FILE_FORMAT_VERSION number correctly (if `python/lsst/cell_coadds/_fits.py` was modified)