### PR TITLE
DM-43585: Persist and read masked fraction planes and noise planes

### DIFF
--- a/python/lsst/cell_coadds/_fits.py
+++ b/python/lsst/cell_coadds/_fits.py
@@ -343,7 +343,9 @@ class CellCoaddFitsReader:
                         data=data[row_id],
                         header=header,
                         common=common,
-                        inputs=inputs[Index2D(data[row_id]["cell_id"][0], data[row_id]["cell_id"][1])],
+                        inputs=inputs[
+                            Index2D(int(data[row_id]["cell_id"][0]), int(data[row_id]["cell_id"][1]))
+                        ],
                         outer_cell_size=outer_cell_size,
                         psf_image_size=psf_image_size,
                         inner_cell_size=grid_cell_size,

--- a/python/lsst/cell_coadds/_fits.py
+++ b/python/lsst/cell_coadds/_fits.py
@@ -112,7 +112,7 @@ from ._multiple_cell_coadd import MultipleCellCoadd, SingleCellCoadd
 from ._uniform_grid import UniformGrid
 from .typing_helpers import SingleCellCoaddApCorrMap
 
-FILE_FORMAT_VERSION = "0.4"
+FILE_FORMAT_VERSION = "0.5"
 """Version number for the file format as persisted, presented as a string of
 the form M.m, where M is the major version, m is the minor version.
 """


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [x] updated the FILE_FORMAT_VERSION number correctly (if `python/lsst/cell_coadds/_fits.py` was modified)